### PR TITLE
Validate all syntaxes

### DIFF
--- a/dbus/dbus-syntax.c
+++ b/dbus/dbus-syntax.c
@@ -4,41 +4,41 @@ dbus_bool_t dbus_validate_path(
     const char *path,
     DBusError  *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 
 dbus_bool_t dbus_validate_interface(
     const char *name,
     DBusError  *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 
 dbus_bool_t dbus_validate_member(
     const char *name,
     DBusError  *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 
 dbus_bool_t dbus_validate_error_name(
     const char *name,
     DBusError *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 
 dbus_bool_t dbus_validate_bus_name(
     const char *name,
     DBusError  *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 
 dbus_bool_t dbus_validate_utf8(
     const char *alleged_utf8,
     DBusError  *error
 ) {
-    return FALSE;
+    return TRUE;
 }
 


### PR DESCRIPTION
Some programs outright don't work if dbus tells them syntax is wrong. (typically chromium errors with `Invalid interface: org.freedesktop.DBus.ObjectManager` for example).

Make them tell everything's alright.